### PR TITLE
BG2-3023: Allow laminas-diactoros 3, so we can use this on PHP 8.5, a…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,15 @@ matrix:
     - php: 8.0
       env:
         - DEPS=latest
-
+    - php: 8.5
+      env:
+        - DEPS=lowest
+    - php: 8.5
+      env:
+        - DEPS=locked
+    - php: 8.5
+      env:
+        - DEPS=latest
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "psr/container": "^2.0",
         "psr/http-server-middleware": "^1.0",
         "mezzio/mezzio-problem-details": "^1.0",
-        "laminas/laminas-diactoros": "^2.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
@@ -15,7 +14,8 @@
         "php-coveralls/php-coveralls": "^2.1",
         "phpstan/phpstan": "^1.2",
         "phpunit/phpunit": "^9.0",
-        "squizlabs/php_codesniffer": "^3.4"
+        "squizlabs/php_codesniffer": "^3.4",
+        "laminas/laminas-diactoros": "^2.0 || ^3.0"
     },
     "license": "BSD-3-Clause",
     "keywords": [


### PR DESCRIPTION
…lso move from require to require-dev

See release notes of diactoros 3: https://github.com/laminas/laminas-diactoros/releases/tag/3.0.0

> For consumers, this version should be entirely backwards compatible in usage. For those extending
> our classes, you will only run into issues when extending implementations of the above interfaces.

But actually searching `diactoros` in the codebase here I see it's only actually used in tests not in the src directory, so what's used here shouldn't affect downstream consumers of the library anyway.